### PR TITLE
feat: add option to insert BOM in generated CSV

### DIFF
--- a/src/common/csv.ts
+++ b/src/common/csv.ts
@@ -5,9 +5,13 @@ const defaultSeparator = ','
 export function csvStringify(data: any[], opt: {
   // header?: string[]
   separator?: string
+  addBom?: boolean // option to add byte order mark for improved Excel support
 } = {}): string {
   const { separator = defaultSeparator } = opt
   let body = ''
+  if (opt.addBom) {
+    body = '\ufeff'
+  }
 
   // Append the header row to the response if requested
   // if (header)


### PR DESCRIPTION
Add option to csvStringify to add a byte order mark so generated CSV files will be opened with the proper encoding in Microsoft Excel.